### PR TITLE
Exposed MMDB reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,36 @@ If the database exists in the default path, the download will be skipped, but ca
 
 ### Available Methods
 
+- getDetails(ip)
+- getCountryDetails(ip)
 - getCountry(ip)
 - getCountryName(ip)
 - getContinent(ip)
 - getContinentName(ip)
+- getASNDetails(ip)
 - getASN(ip)
 - getASNName(ip)
 - getASNDomain(ip)
+- close()
+
+### Using the MMDB reader separately
+
+Advanced users can use the MMDB reader that is included in the installation.
+
+#### Sample Usage
+```python
+>>> from ipinfo_db.reader import Reader
+>>> db = Reader('PATH_TO_MMDB_FILE')
+>>> result = db.get('IP')
+>>> result
+```
+#### Available Methods
+
+- open(path)
+- close()
+- metadata()
+- get(ip)
+- getWithPrefixLen(ip)
 
 ## Other Libraries
 

--- a/ipinfo_db/client.py
+++ b/ipinfo_db/client.py
@@ -137,4 +137,3 @@ class Client:
         :rtype: dict
         '''
         return self.reader.getASNDetails(ip)
-    

--- a/ipinfo_db/client.py
+++ b/ipinfo_db/client.py
@@ -45,25 +45,10 @@ class Client:
         # Read the mmdb file.
         self.db = Reader(self.path)
 
-    def open(self, path):
-        '''Opens the mmdb file located at the given path.
-
-        :param path: Path to mmdb file.
-        '''
-        self.db.open(path)
-
     def close(self):
         '''Closes the mmdb file.
         '''
         self.db.close()
-
-    def getMetadata(self):
-        '''Returns the metadata associated with the mmdb file.
-
-        :return: metadata of the mmdb file.
-        :rtype: Metadata
-        '''
-        return self.db.metadata()
 
     def getDetails(self, ip):
         '''Returns all the country and ASN level IP information available for the input IP address in a dictionary format.

--- a/ipinfo_db/client.py
+++ b/ipinfo_db/client.py
@@ -20,7 +20,6 @@ class Client:
         self.access_token = access_token
         self.path = path
         self.replace = replace
-        self.reader = Reader()
 
         if self.access_token is None and self.path is None:
             raise SyntaxError("Token or Path is required")
@@ -44,7 +43,27 @@ class Client:
             urllib.request.urlretrieve(DB_DOWNLOAD_URL+self.access_token, self.path)
 
         # Read the mmdb file.
-        self.db = self.reader.read(self.path)
+        self.db = Reader(self.path)
+
+    def open(self, path):
+        '''Opens the mmdb file located at the given path.
+
+        :param path: Path to mmdb file.
+        '''
+        self.db.open(path)
+
+    def close(self):
+        '''Closes the mmdb file.
+        '''
+        self.db.close()
+
+    def getMetadata(self):
+        '''Returns the metadata associated with the mmdb file.
+
+        :return: metadata of the mmdb file.
+        :rtype: Metadata
+        '''
+        return self.db.metadata()
 
     def getDetails(self, ip):
         '''Returns all the country and ASN level IP information available for the input IP address in a dictionary format.
@@ -53,7 +72,7 @@ class Client:
         :return: All available country and ASN level information of the IP address.
         :rtype: dict
         '''
-        return self.reader.getDetails(ip)
+        return self.db.get(ip)
 
     def getCountry(self, ip):
         '''Returns the ISO 3166 country code of the input.
@@ -62,7 +81,7 @@ class Client:
         :return: Country code of the IP address.
         :rtype: str
         '''
-        return self.reader.getCountry(ip)
+        return self._get_data_field(ip, 'country')
     
     def getCountryName(self, ip):
         '''Returns the country name of the input IP address.
@@ -71,7 +90,7 @@ class Client:
         :return: Country name of the IP address.
         :rtype: str
         '''
-        return self.reader.getCountryName(ip)
+        return self._get_data_field(ip, 'country_name')
     
     def getContinent(self, ip):
         '''Returns the continent shortcode of the input IP address.
@@ -80,7 +99,7 @@ class Client:
         :return: Continent code of the IP address.
         :rtype: str
         '''
-        return self.reader.getContinent(ip)
+        return self._get_data_field(ip, 'continent')
     
     def getContinentName(self, ip):
         '''Returns the name of the continent of the input IP address.
@@ -89,7 +108,7 @@ class Client:
         :return: Continent name of the IP address.
         :rtype: str
         '''
-        return self.reader.getContinentName(ip)
+        return self._get_data_field(ip, 'continent_name')
     
     def getASN(self, ip):
         '''Returns the ASN (Autonomous System Number) of the input IP address.
@@ -98,7 +117,7 @@ class Client:
         :return: ASN (i.e. 	AS2381) of the IP address.
         :rtype: str
         '''
-        return self.reader.getASN(ip)
+        return self._get_data_field(ip, 'asn')
     
     def getASNName(self, ip):
         '''Returns the AS (Autonomous System) organization of the input ip address.
@@ -107,7 +126,7 @@ class Client:
         :return: AS name of the IP address.
         :rtype: str
         '''
-        return self.reader.getASNName(ip)
+        return self._get_data_field(ip, 'as_name')
     
     def getASNDomain(self, ip):
         '''Returns the domain or the official website of the input IP address.
@@ -116,7 +135,7 @@ class Client:
         :return: Domain or website of the AS organization owning the IP address.
         :rtype: str
         '''
-        return self.reader.getASNDomain(ip)
+        return self._get_data_field(ip, 'as_domain')
 
     def getCountryDetails(self, ip):
         '''Returns the country level geolocation information of the input ip address.
@@ -126,7 +145,8 @@ class Client:
         :return: Country and continent information of the IP address.
         :rtype: dict
         '''
-        return self.reader.getCountryDetails(ip)
+        fields = ["country", "country_name", "continent", "continent_name"]
+        return self._get_data_dictionary(ip, fields)
 
     def getASNDetails(self, ip):
         '''Returns all the available ASN-level information of the input IP address.
@@ -136,4 +156,13 @@ class Client:
         :return: ASN-level information of the IP address.
         :rtype: dict
         '''
-        return self.reader.getASNDetails(ip)
+        fields = ["asn", "as_domain", "as_name"]
+        return self._get_data_dictionary(ip, fields)
+    
+    def _get_data_field(self, ip, field):
+        data = self.db.get(ip)
+        return data[field] if data else None
+
+    def _get_data_dictionary(self, ip, fields):
+        data = self.db.get(ip)
+        return {key:data[key] for key in fields if key in data}

--- a/ipinfo_db/reader.py
+++ b/ipinfo_db/reader.py
@@ -3,17 +3,47 @@ import maxminddb
 class Reader:
 
     def __init__(self, path):
+        '''Initiates Reader object with the given path.
+
+        :param: path: Path to the mmdb file.
+        '''
         self.db = maxminddb.open_database(path)
 
     def open(self, path):
+        '''Opens an mmdb file located at the given path. Closes previously opened database.
+
+        :param: path: Path to the mmdb file.
+        '''
         self.close()
         self.db = maxminddb.open_database(path)
 
     def close(self):
+        '''Closes the database.
+        '''
         self.db.close()
 
-    def get(self, ip):
-        return self.db.get(ip)
-    
     def metadata(self):
+        '''Returns the metadata associated with the mmdb file.
+
+        :return: metadata of the mmdb file.
+        :rtype: Metadata
+        '''
         return self.db.metadata()
+
+    def get(self, ip):
+        '''Returns the database record for the given IP address.
+
+        :param: ip: An IP address in string format. Can be either IPv4 or IPv6.
+        :return: Database record for the given IP.
+        :rtype: Record
+        '''
+        return self.db.get(ip)
+
+    def getWithPrefixLen(self, ip):
+        '''Returns a tuple containing the database record and the associated (network) prefix length.
+
+        :param: ip: An IP address in string format. Can be either IPv4 or IPv6.
+        :return: A tuple containing the database record and the prefix length.
+        :rtype: Tuple
+        '''
+        return self.db.get_with_prefix_len(ip)

--- a/ipinfo_db/reader.py
+++ b/ipinfo_db/reader.py
@@ -3,7 +3,7 @@ import maxminddb
 class Reader:
 
     def __init__(self, path):
-        '''Initiates Reader object with the given path.
+        '''Initializes the Reader object with the given path.
 
         :param: path: Path to the mmdb file.
         '''

--- a/ipinfo_db/reader.py
+++ b/ipinfo_db/reader.py
@@ -2,117 +2,18 @@ import maxminddb
 
 class Reader:
 
-    def __init__(self):
-        self.db = None
-
-    def read(self, path):
-        '''Opens the MMDB file located at the given path.
-
-        :param: path: Path to MMDB file.
-        :return: db reader.
-        :rtype: Reader
-        '''
+    def __init__(self, path):
         self.db = maxminddb.open_database(path)
-        return self.db
-    
-    def getDetails(self, ip):
-        '''Returns all the country and ASN level IP information available for the input IP address in a dictionary format.
 
-        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
-        :return: All available country and ASN level information of the IP address.
-        :rtype: dict
-        '''
+    def open(self, path):
+        self.close()
+        self.db = maxminddb.open_database(path)
+
+    def close(self):
+        self.db.close()
+
+    def get(self, ip):
         return self.db.get(ip)
-
-    def getCountry(self, ip):
-        '''Returns the ISO 3166 country code of the input.
-
-        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
-        :return: Country code of the IP address.
-        :rtype: str
-        '''
-        return self._get_data_field(ip, 'country')
     
-    def getCountryName(self, ip):
-        '''Returns the country name of the input IP address.
-
-        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
-        :return: Country name of the IP address.
-        :rtype: str
-        '''
-        return self._get_data_field(ip, 'country_name')
-    
-    def getContinent(self, ip):
-        '''Returns the continent shortcode of the input IP address.
-
-        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
-        :return: Continent code of the IP address.
-        :rtype: str
-        '''
-        return self._get_data_field(ip, 'continent')
-    
-    def getContinentName(self, ip):
-        '''Returns the name of the continent of the input IP address.
-
-        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
-        :return: Continent name of the IP address.
-        :rtype: str
-        '''
-        return self._get_data_field(ip, 'continent_name')
-    
-    def getASN(self, ip):
-        '''Returns the ASN (Autonomous System Number) of the input IP address.
-
-        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
-        :return: ASN (i.e. 	AS2381) of the IP address.
-        :rtype: str
-        '''
-        return self._get_data_field(ip, 'asn')
-    
-    def getASNName(self, ip):
-        '''Returns the AS (Autonomous System) organization of the input ip address.
-
-        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
-        :return: AS name of the IP address.
-        :rtype: str
-        '''
-        return self._get_data_field(ip, 'as_name')
-    
-    def getASNDomain(self, ip):
-        '''Returns the domain or the official website of the input IP address.
-
-        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
-        :return: Domain or website of the AS organization owning the IP address.
-        :rtype: str
-        '''
-        return self._get_data_field(ip, 'as_domain')
-
-    def getCountryDetails(self, ip):
-        '''Returns the country level geolocation information of the input ip address.
-        country, country_name, continent, and continent_name
-
-        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
-        :return: Country and continent information of the IP address.
-        :rtype: dict
-        '''
-        fields = ["country", "country_name", "continent", "continent_name"]
-        return self._get_data_dictionary(ip, fields)
-
-    def getASNDetails(self, ip):
-        '''Returns all the available ASN-level information of the input IP address.
-        asn, as name, and as_domain
-
-        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
-        :return: ASN-level information of the IP address.
-        :rtype: dict
-        '''
-        fields = ["asn", "as_domain", "as_name"]
-        return self._get_data_dictionary(ip, fields)
-    
-    def _get_data_field(self, ip, field):
-        data = self.db.get(ip)
-        return data[field] if data else None
-
-    def _get_data_dictionary(self, ip, fields):
-        data = self.db.get(ip)
-        return {key:data[key] for key in fields if key in data}
+    def metadata(self):
+        return self.db.metadata()

--- a/ipinfo_db/reader.py
+++ b/ipinfo_db/reader.py
@@ -1,0 +1,118 @@
+import maxminddb
+
+class Reader:
+
+    def __init__(self):
+        self.db = None
+
+    def read(self, path):
+        '''Opens the MMDB file located at the given path.
+
+        :param: path: Path to MMDB file.
+        :return: db reader.
+        :rtype: Reader
+        '''
+        self.db = maxminddb.open_database(path)
+        return self.db
+    
+    def getDetails(self, ip):
+        '''Returns all the country and ASN level IP information available for the input IP address in a dictionary format.
+
+        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
+        :return: All available country and ASN level information of the IP address.
+        :rtype: dict
+        '''
+        return self.db.get(ip)
+
+    def getCountry(self, ip):
+        '''Returns the ISO 3166 country code of the input.
+
+        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
+        :return: Country code of the IP address.
+        :rtype: str
+        '''
+        return self._get_data_field(ip, 'country')
+    
+    def getCountryName(self, ip):
+        '''Returns the country name of the input IP address.
+
+        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
+        :return: Country name of the IP address.
+        :rtype: str
+        '''
+        return self._get_data_field(ip, 'country_name')
+    
+    def getContinent(self, ip):
+        '''Returns the continent shortcode of the input IP address.
+
+        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
+        :return: Continent code of the IP address.
+        :rtype: str
+        '''
+        return self._get_data_field(ip, 'continent')
+    
+    def getContinentName(self, ip):
+        '''Returns the name of the continent of the input IP address.
+
+        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
+        :return: Continent name of the IP address.
+        :rtype: str
+        '''
+        return self._get_data_field(ip, 'continent_name')
+    
+    def getASN(self, ip):
+        '''Returns the ASN (Autonomous System Number) of the input IP address.
+
+        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
+        :return: ASN (i.e. 	AS2381) of the IP address.
+        :rtype: str
+        '''
+        return self._get_data_field(ip, 'asn')
+    
+    def getASNName(self, ip):
+        '''Returns the AS (Autonomous System) organization of the input ip address.
+
+        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
+        :return: AS name of the IP address.
+        :rtype: str
+        '''
+        return self._get_data_field(ip, 'as_name')
+    
+    def getASNDomain(self, ip):
+        '''Returns the domain or the official website of the input IP address.
+
+        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
+        :return: Domain or website of the AS organization owning the IP address.
+        :rtype: str
+        '''
+        return self._get_data_field(ip, 'as_domain')
+
+    def getCountryDetails(self, ip):
+        '''Returns the country level geolocation information of the input ip address.
+        country, country_name, continent, and continent_name
+
+        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
+        :return: Country and continent information of the IP address.
+        :rtype: dict
+        '''
+        fields = ["country", "country_name", "continent", "continent_name"]
+        return self._get_data_dictionary(ip, fields)
+
+    def getASNDetails(self, ip):
+        '''Returns all the available ASN-level information of the input IP address.
+        asn, as name, and as_domain
+
+        :param: ip: Input IP address. Supports both IPv4 and IPv6 address.
+        :return: ASN-level information of the IP address.
+        :rtype: dict
+        '''
+        fields = ["asn", "as_domain", "as_name"]
+        return self._get_data_dictionary(ip, fields)
+    
+    def _get_data_field(self, ip, field):
+        data = self.db.get(ip)
+        return data[field] if data else None
+
+    def _get_data_dictionary(self, ip, fields):
+        data = self.db.get(ip)
+        return {key:data[key] for key in fields if key in data}

--- a/ipinfo_db/version.py
+++ b/ipinfo_db/version.py
@@ -1,1 +1,1 @@
-SDK_VERSION = "0.0.2"
+SDK_VERSION = "0.0.3"

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -6,26 +6,26 @@ client = ipinfo_db.Client(path='./tests/tests_db.mmdb')
 
 
 def test_get_country():
-    assert(client.getCountry("8.8.8.8"), "US")
+    assert client.getCountry("8.8.8.8") == "US"
 
 def test_get_country_name():
-    assert(client.getCountryName('8.8.8.8'),"United States")
+    assert client.getCountryName('8.8.8.8') == "United States"
 
 def test_get_continent():
-    assert(client.getContinent('8.8.8.8'),"NA")
+    assert client.getContinent('8.8.8.8') == "NA"
 
 def test_get_continent_name():
-    assert(client.getContinentName('8.8.8.8'),"North America")
+    assert client.getContinentName('8.8.8.8') == "North America"
 
 def test_get_asn():
-    assert(client.getASN('8.8.8.8'),"AS15169")
+    assert client.getASN('8.8.8.8') == "AS15169"
 
 def test_get_asn_name():
-    assert(client.getASNName('8.8.8.8'),"Google LLC")
+    assert client.getASNName('8.8.8.8') == "Google LLC"
 
 def test_get_asn_domain():
-    assert(client.getASNDomain('8.8.8.8'),"google.com")
+    assert client.getASNDomain('8.8.8.8') == "google.com"
 
 def test_no_ip_details():
-    assert(client.getDetails('127.0.0.1'), None)
-    assert(client.getCountry('127.0.0.1'), None)
+    assert client.getDetails('127.0.0.1') is None
+    assert client.getCountry('127.0.0.1') is None


### PR DESCRIPTION
Made separate MMDB reader module. Supports following methods
- `open`; open an MMDB file
- `close` ; close the currently open MMDB file
- `getMetadata`; get metadata associated with the currently open MMDB file
- `get`; get a record
- `getWithPrefixLen`; get a tuple containing record and network prefix length.